### PR TITLE
Fix ODE tutorial link

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -69,7 +69,7 @@ page.
 
 To understand the package in more detail, check out the following tutorials in
 this manual. **It is highly recommended that new users start with the
-[ODE tutorial](/tutorials/ode_example.html)**. Example IJulia notebooks
+[ODE tutorial](tutorials/ode_example.html)**. Example IJulia notebooks
 [can also be found in DiffEqTutorials.jl](https://github.com/JuliaDiffEq/DiffEqTutorials.jl).
 If you find any example where there seems to be an error, please open an issue.
 


### PR DESCRIPTION
I was reading the getting started page and noticed this link was broken. Looks like it should be a relative path.