### PR TITLE
Fix link to ODE tutorial in faq

### DIFF
--- a/docs/src/basics/faq.md
+++ b/docs/src/basics/faq.md
@@ -53,7 +53,7 @@ apply. What you want to do first is make sure your function does not allocate.
 If your system is small (`<=100` ODEs/SDEs/DDEs/DAEs?), then you should set your
 system up to use [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl).
 This is demonstrated
-[http://docs.juliadiffeq.org/latest/tutorials/ode_example.html#Example-3:-Using-Other-Types-for-Systems-of-Equations-1](in the ODE tutorial)
+[in the ODE tutorial](http://docs.juliadiffeq.org/latest/tutorials/ode_example.html#Example-3:-Using-Other-Types-for-Systems-of-Equations-1)
 with static matrices. Static vectors/arrays are stack-allocated, and thus creating
 new arrays is free and the compiler doesn't have to heap-allocate any of the
 temporaries (that's the expensive part!). These have specialized super fast


### PR DESCRIPTION
Markdown link syntax was reversed