### PR TITLE
Typo in performance_overloads

### DIFF
--- a/docs/src/features/performance_overloads.md
+++ b/docs/src/features/performance_overloads.md
@@ -45,7 +45,7 @@ is necessary. For the DAE
 G(du,u,p,t) = res
 ```
 
-The Jacobian should be given in the form `dG/du + gamma*dG/d(du)` where `gamma`
+The Jacobian should be given in the form `gamma*dG/d(du) + dG/du ` where `gamma`
 is given by the solver. This means that the signature is:
 
 ```julia

--- a/docs/src/features/performance_overloads.md
+++ b/docs/src/features/performance_overloads.md
@@ -45,7 +45,7 @@ is necessary. For the DAE
 G(du,u,p,t) = res
 ```
 
-The Jacobian should be given in the form `dG/d(du) + gamma*dG/du` where `gamma`
+The Jacobian should be given in the form `dG/du + gamma*dG/d(du)` where `gamma`
 is given by the solver. This means that the signature is:
 
 ```julia


### PR DESCRIPTION
The documentation for the DAE Jacobian uses `gamma` differently than the provided example. It's the example, and not the stated version, that appears to work for me.