### PR TITLE
Explicitly naming DEIntegrator in docs

### DIFF
--- a/docs/src/basics/integrator.md
+++ b/docs/src/basics/integrator.md
@@ -301,7 +301,7 @@ solve!(integrator)
 
 ## Plot Recipe
 
-Like the `Solution` type, a plot recipe is provided for the `DEIntegrator` type.
+Like the `DESolution` type, a plot recipe is provided for the `DEIntegrator` type.
 Since the `DEIntegrator` type is a local state type on the current interval,
 `plot(integrator)` returns the solution on the current interval. The same
 options for the plot recipe are provided as for `sol`, meaning one can choose

--- a/docs/src/basics/integrator.md
+++ b/docs/src/basics/integrator.md
@@ -14,7 +14,7 @@ integrator = init(prob,alg;kwargs...)
 ```
 
 The keyword args which are accepted are the same [Common Solver Options](@ref)
-used by `solve`. The type which is returned is the integrator. One can manually
+used by `solve`. The type which is returned is an `integrator<:DEIntegrator`. One can manually
 choose to step via the `step!` command:
 
 ```julia
@@ -85,7 +85,7 @@ and then `solve!` is equivalent to `solve`.
 
 ## Handing Integrators
 
-The `integrator` type holds all of the information for the intermediate solution
+The `integrator<:DEIntegrator` type holds all of the information for the intermediate solution
 of the differential equation. Useful fields are:
 
 * `t` - time of the proposed step
@@ -137,7 +137,7 @@ inefficient as `reinit!`.
 The integrator and the solution have very different actions because they have
 very different meanings. The `Solution` type is a type with history: it stores
 all of the (requested) timepoints and interpolates/acts using the values closest
-in time. On the other hand, the `Integrator` type is a local object. It only knows
+in time. On the other hand, the `integrator<:DEIntegrator` type is a local object. It only knows
 the times of the interval it currently spans, the current caches and values,
 and the current state of the solver (the current options, tolerances, etc.).
 These serve very different purposes:
@@ -300,8 +300,8 @@ solve!(integrator)
 
 ## Plot Recipe
 
-Like the `Solution` type, a plot recipe is provided for the `Integrator` type.
-Since the `Integrator` type is a local state type on the current interval,
+Like the `Solution` type, a plot recipe is provided for the `DEIntegrator` type.
+Since the `DEIntegrator` type is a local state type on the current interval,
 `plot(integrator)` returns the solution on the current interval. The same
 options for the plot recipe are provided as for `sol`, meaning one can choose
 variables via the `vars` keyword argument, or change the `plotdensity` / turn

--- a/docs/src/basics/integrator.md
+++ b/docs/src/basics/integrator.md
@@ -14,8 +14,8 @@ integrator = init(prob,alg;kwargs...)
 ```
 
 The keyword args which are accepted are the same [Common Solver Options](@ref)
-used by `solve`. The type which is returned is an `integrator<:DEIntegrator`. One can manually
-choose to step via the `step!` command:
+used by `solve` and the returned value is an `integrator` which satisfies
+`typeof(integrator)<:DEIntegrator`. One can manually choose to step via the `step!` command:
 
 ```julia
 step!(integrator)
@@ -135,12 +135,13 @@ inefficient as `reinit!`.
 ### Integrator vs Solution
 
 The integrator and the solution have very different actions because they have
-very different meanings. The `Solution` type is a type with history: it stores
+very different meanings. The `typeof(sol) <: DESolution` type is a type with 
+history: it stores
 all of the (requested) timepoints and interpolates/acts using the values closest
-in time. On the other hand, the `integrator<:DEIntegrator` type is a local object. It only knows
-the times of the interval it currently spans, the current caches and values,
-and the current state of the solver (the current options, tolerances, etc.).
-These serve very different purposes:
+in time. On the other hand, the `typeof(integrator)<:DEIntegrator` type is a 
+local object. It only knows the times of the interval it currently spans, 
+the current caches and values, and the current state of the solver 
+(the current options, tolerances, etc.). These serve very different purposes:
 
 * The `integrator`'s interpolation can extrapolate, both forward and backward in
   in time. This is used to estimate events and is internally used for predictions.


### PR DESCRIPTION
The documentation doesn't explicitly name the composite type `DEIntegrator`. It refers mainly to the instance `integrator` (and sometimes `Integrator`). I've therefore added `DEIntegrator` in a few places. (I needed to know because I wanted to set a dispatch pattern for a callback condition.) 

On another note, there is a discrepancy, where the documentation shows the prototype `reinit!(integrator::ODEIntegrator …)`, whereas the code docstring says `reinit!(integrator::DDEIntegrator …`. I suspect these should be made consistent with each other, but I wasn't sure whether it should be `DEIntegrator`/`ODEIntegrator`/`DDEIntegrator`. My guess is `DEIntegrator` since that is most general, and `reinit!` seems to be quite general. But I wasn't sure, so I didn't change it.