### PR TITLE
More referencing of integrator interface

### DIFF
--- a/docs/src/features/callback_functions.md
+++ b/docs/src/features/callback_functions.md
@@ -31,7 +31,7 @@ The arguments are defined as follows:
 
 * `condition`: This is a function `condition(u,t,integrator)` for declaring when
   the callback should be used. A callback is initiated if the condition hits
-  `0` within the time interval.
+  `0` within the time interval. See the [Integrator Interface](@ref) documentation for information about `integrator`.
 * `affect!`: This is the function `affect!(integrator)` where one is allowed to
   modify the current state of the integrator. If you do not pass an `affect_neg!`
   function, it is called when `condition` is found to be `0` (at a root) and
@@ -85,7 +85,7 @@ DiscreteCallback(condition,affect!;
 
 * `condition`: This is a function `condition(u,t,integrator)` for declaring when
   the callback should be used. A callback is initiated if the condition evaluates
-  to `true`.
+  to `true`. See the [Integrator Interface](@ref) documentation for information about `integrator`.
 * `affect!`: This is the function `affect!(integrator)` where one is allowed to
   modify the current state of the integrator. For more information on what can
   be done, see the [Integrator Interface](@ref) manual page.


### PR DESCRIPTION
In the `condition` description, I added a reference to the manual page on integrator interface. This is to make it more explicit, since `integrator` is not described until the next bullet point.