### PR TITLE
Remove the box around docstrings

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,7 @@ makedocs(modules=[DiffEqBase,DiffEqPDEBase,DiffEqProblemLibrary],
          format =:html,
          sitename="DifferentialEquations.jl",
          authors="Chris Rackauckas",
+         assets = ["assets/custom.css"],
          pages = Any[
          "Home" => "index.md",
          "Tutorials" => Any[

--- a/docs/src/assets/custom.css
+++ b/docs/src/assets/custom.css
@@ -1,0 +1,3 @@
+article section.docstring {
+    border: none;
+}


### PR DESCRIPTION
It produces something like this:

![image](https://user-images.githubusercontent.com/29282/47246186-5398e000-d3b1-11e8-9523-0221afc08667.png)

See: https://github.com/JuliaDiffEq/DifferentialEquations.jl/issues/371
