### PR TITLE
Fix adjoint SA equation

### DIFF
--- a/docs/src/analysis/sensitivity.md
+++ b/docs/src/analysis/sensitivity.md
@@ -191,7 +191,7 @@ G(u,p)=G(u(p))=\int_{t_{0}}^{T}g(u(t,p))dt
 some integral of the solution. It does so by solving the adjoint problem
 
 ```math
-\frac{d\lambda^{\star}}{dt}=-g_{u}(t)-\lambda^{\star}(t)f_{u}(t),\thinspace\thinspace\thinspace\lambda^{\star}(T)=0
+\frac{d\lambda^{\star}}{dt}=g_{u}(t)-\lambda^{\star}(t)f_{u}(t),\thinspace\thinspace\thinspace\lambda^{\star}(T)=0
 ```
 
 where ``f_u`` is the Jacobian of the system with respect to the state `u` while


### PR DESCRIPTION
This fixes the fix of #154. :face_with_head_bandage: I took a look on the adjoint equation again today and found that my previous "fix" is wrong. The sign of `\lambda` in the integral
```
\int_{t_{0}}^{T} +\lambda^{\star}(t) f_{p}(t)+g_{p}(t)dt+...
```
is positive, thus, in the equation
```
\frac{d\lambda^{\star}}{dt}=g_{u}(t)-\lambda^{\star}(t)f_{u}(t),\thinspace\thinspace\thinspace\lambda^{\star}(T)=0
```
`g` should be positive, too.