### PR TITLE
Fix typo

### DIFF
--- a/docs/src/solvers/ode_solve.md
+++ b/docs/src/solvers/ode_solve.md
@@ -252,7 +252,7 @@ Royal Society, 2011.).
   (free 3rd order Hermite interpolant). Fixed timestep only. Designed for hyperbolic PDEs (stability properties).
 - `NDBLSRK144` - 14-stage, fourth order low-storage method with optimized
   stability regions for advection-dominated problems. Fixed timestep only.
-- `NDBLSRK144` - 12-stage, fourth order low-storage method with optimized
+- `NDBLSRK124` - 12-stage, fourth order low-storage method with optimized
   stability regions for advection-dominated problems. Fixed timestep only.
 - `CFRLDDRK64` - 6-stage, fourth order low-storage, low-dissipation,
   low-dispersion scheme. Fixed timestep only.


### PR DESCRIPTION
Code from [OrdinaryDiffEq.jl/src/alg_utils.jl](https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/src/alg_utils.jl) lines 195 - 197
```
alg_order(alg::NDBLSRK124) = 4
alg_order(alg::NDBLSRK134) = 4
alg_order(alg::NDBLSRK144) = 4
```
`NDBLSRK124` is the 12 stage, fourth order
`NDBLSRK134` is the 13 stage, fourth order