### PR TITLE
Document :Terminated retcode

### DIFF
--- a/docs/src/basics/integrator.md
+++ b/docs/src/basics/integrator.md
@@ -199,8 +199,10 @@ The following functions make up the interface:
   `integrator` to match that of `integrator2`. Note that due to PI control and
   step acceleration this is more than matching the factors in most cases.
 * `proposed_dt(integrator)`: Returns the `dt` of the proposed step.
-* `terminate!(integrator)`: Terminates the integrator by emptying `tstops`. This
-  can be used in events and callbacks to immediately end the solution process.
+* `terminate!(integrator[, retcode = :Terminated])`: Terminates the integrator
+  by emptying `tstops`. This can be used in events and callbacks to immediately
+  end the solution process.  Optionally, `retcode` may be specified (see:
+  [Return Codes (RetCodes)](@ref)).
 * `change_t_via_interpolation!(integrator,t,modify_save_endpoint=Val{false})`: This
   option lets one modify the current `t` and changes all of the corresponding
   values using the local interpolation. If the current solution has already

--- a/docs/src/basics/solution.md
+++ b/docs/src/basics/solution.md
@@ -164,6 +164,10 @@ error state of the solution. The retcodes are as follows:
 
 - `:Default`: The solver did not set retcodes.
 - `:Success`: The integration completed without erroring.
+- `:Terminated`: The integration is terminated with `terminate!(integrator)`.
+  Note that this may occur by using `TerminateSteadyState` from the callback
+  library `DiffEqCallbacks` or, consequently, steady state solver `DynamicSS`
+  from `SteadyStateDiffEq`.
 - `:MaxIters`: The integration exited early because it reached its maximum number
   of iterations.
 - `:DtLessThanMin`: The timestep method chose a stepsize which is smaller than the


### PR DESCRIPTION
It seems a new `retcode` is added in https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/554. This PR notes that in the documentation.