### PR TITLE
DiffEqBiological API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: julia
 os:
   - linux
 julia:
-  - 1.0
+  - 1.1
 notifications:
   email: false
 script:

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+DiffEqBiological = "eb300fae-53e8-50a0-950c-e21f52c2b7e0"
 DiffEqPDEBase = "34035eb4-37db-58ae-b003-a3202c898701"
 DiffEqProblemLibrary = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
-julia 0.5
+julia 1.1
 DiffEqProblemLibrary
+DiffEqBiological 3.6.1

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
-using Documenter,DiffEqBase,DiffEqPDEBase,DiffEqProblemLibrary
+using Documenter,DiffEqBase,DiffEqPDEBase,DiffEqProblemLibrary,DiffEqBiological
 
-makedocs(modules=[DiffEqBase,DiffEqPDEBase,DiffEqProblemLibrary],
+makedocs(modules=[DiffEqBase,DiffEqPDEBase,DiffEqProblemLibrary,DiffEqBiological],
          doctest=false, clean=true,
          format =:html,
          sitename="DifferentialEquations.jl",
@@ -84,6 +84,9 @@ makedocs(modules=[DiffEqBase,DiffEqPDEBase,DiffEqProblemLibrary],
              "models/financial.md",
              "models/biological.md",
              "models/external_modeling.md"
+         ],
+         "APIs" => Any[
+             "apis/diffeqbio.md"
          ],
          "Extra Details" => Any[
              "extras/timestepping.md",

--- a/docs/src/apis/diffeqbio.md
+++ b/docs/src/apis/diffeqbio.md
@@ -1,0 +1,68 @@
+# DiffEqBiological.jl API
+```@meta
+CurrentModule = DiffEqBiological
+```
+
+## Reaction Network Generation Macros
+```@docs
+@min_reaction_network
+@reaction_network
+```
+
+## `@min_reaction_network` modifiers
+```@docs
+addodes!
+addsdes!
+addjumps!
+```
+
+## Basic properties
+```@docs
+speciesmap
+paramsmap 
+numspecies 
+numparams
+numreactions
+```
+
+## Reaction Properties
+```@docs
+substrates
+products
+dependents
+dependants
+ismassaction
+substratestoich
+productstoich
+netstoich
+```
+
+## Generated Functions for Models
+```@docs
+oderhsfun
+jacfun
+paramjacfun
+odefun
+noisefun
+sdefun
+jumps
+regularjumps
+```
+
+## Generated Expressions
+```@docs
+odeexprs
+jacobianexprs
+noiseexprs
+jumpexprs
+rateexpr
+oderatelawexpr
+ssaratelawexpr
+```
+
+## Dependency Graphs
+```@docs
+rxtospecies_depgraph
+speciestorx_depgraph
+rxtorx_depgraph
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -246,6 +246,18 @@ Pages = [
 Depth = 2
 ```
 
+### APIs
+
+Some DifferentialEquations.jl packages provide documented APIs, these include:
+```@contents
+Pages = [
+    "apis/diffeqbio.md"
+]
+Depth = 2
+```
+
+
+
 ### Extra Details
 
 These are just assorted extra explanations for the curious.


### PR DESCRIPTION
This adds a new sidebar category for APIs, with a page containing a generated API for `DiffEqBiological` based on the comments I've added there. On my computer the webpages generate fine and look good.

Note, this make DiffEqDocs depend on DiffEqBiological. As the later needs Julia 1.1 I bumped REQUIRE and travis to 1.1. 