### PR TITLE
Document required signature of model f in global_sensitivity.md

### DIFF
--- a/docs/src/analysis/global_sensitivity.md
+++ b/docs/src/analysis/global_sensitivity.md
@@ -43,7 +43,8 @@ individual contribution.
 
 `morris_effects = morris_sensitivity(prob::DiffEqBase.DEProblem,alg,t,param_range,param_steps;kwargs...)`
 
-Here, `f` is just the model (as a julia function or a `DEProblem`) you want to
+Here, `f` is just the model (as a julia function 
+`f(input_vector) -> output_vector` or a `DEProblem`) you want to
 run the analysis on, `param_range` requires an array of 2-tuples with the lower bound
 and the upper bound, `param_steps` decides the value of ``\Delta`` in the equation
 above and `relative_scale`, the above equation takes the assumption that


### PR DESCRIPTION
Documentation on the global sensitivity analysis is currently quite sparse.

The analysis does not work with models `f` that return a single output. The information that the model needs to output a vector (instead of a single value) would have saved me time. Therefore, I suggest to add it here.