### PR TITLE
API documentation skeleton for DiffEqBase

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -87,6 +87,21 @@ makedocs(modules=[DiffEqBase,DiffEqPDEBase,DiffEqProblemLibrary,DiffEqBiological
              "models/external_modeling.md"
          ],
          "APIs" => Any[
+             "DiffEqBase API" => [
+                 "Overview" => "apis/diffeqbase/overview.md",
+                 "apis/diffeqbase/functions.md",
+                 "apis/diffeqbase/problems.md",
+                 "apis/diffeqbase/solutions.md",
+                 "apis/diffeqbase/solvers.md",
+                 "apis/diffeqbase/de_types.md",
+                 "apis/diffeqbase/operators.md",
+                 "apis/diffeqbase/callbacks.md",
+                 "apis/diffeqbase/interpolation.md",
+                 "apis/diffeqbase/ensembles.md",
+                 "apis/diffeqbase/data_arrays.md",
+                 "apis/diffeqbase/noise.md",
+                 "apis/diffeqbase/utility.md",
+             ],
              "apis/diffeqbio.md"
          ],
          "Extra Details" => Any[

--- a/docs/src/apis/diffeqbase/callbacks.md
+++ b/docs/src/apis/diffeqbase/callbacks.md
@@ -1,0 +1,23 @@
+# Callbacks
+
+
+## Types
+
+```@docs
+DiffEqBase.DECallback
+DiffEqBase.AbstractDiscreteCallback
+DiscreteCallback
+DiffEqBase.AbstractContinuousCallback
+ContinuousCallback
+VectorContinuousCallback
+CallbackSet
+DiffEqBase.CallbackCache
+```
+
+
+## Functions
+
+```@docs
+DiffEqBase.split_callbacks
+DiffEqBase.initialize!(cb::CallbackSet, u, t, integrator)
+```

--- a/docs/src/apis/diffeqbase/data_arrays.md
+++ b/docs/src/apis/diffeqbase/data_arrays.md
@@ -1,0 +1,13 @@
+# Data arrays
+
+
+## Types
+
+```@docs
+DEDataArray
+```
+
+### Aliases
+
+* `DEDataVector{T}`: `DEDataArray{T, 1}`
+* `DEDataMatrix{T}`: `DEDataArray{T, 2}`

--- a/docs/src/apis/diffeqbase/de_types.md
+++ b/docs/src/apis/diffeqbase/de_types.md
@@ -1,0 +1,219 @@
+# [DE types](@id de_types)
+
+
+## Discrete
+
+```@docs
+DiffEqBase.AbstractDiscreteFunction
+DiscreteFunction
+DiffEqBase.AbstractDiscreteProblem
+DiscreteProblem
+```
+
+## ODE
+
+```@docs
+DiffEqBase.AbstractODEFunction
+ODEFunction
+DiffEqBase.AbstractODEProblem
+ODEProblem
+DiffEqBase.StandardODEProblem
+DiffEqBase.AbstractODESolution
+DiffEqBase.ODESolution
+DiffEqBase.AbstractODEAlgorithm
+DiffEqBase.AbstractODEIntegrator
+```
+
+### Dynamical ODEs
+
+```@docs
+DynamicalODEFunction
+DiffEqBase.AbstractDynamicalODEProblem
+DynamicalODEProblem
+```
+
+### Second-order ODEs
+
+```@docs
+DiffEqBase.AbstractSecondOrderODEProblem
+SecondOrderODEProblem
+DiffEqBase.AbstractSecondOrderODEAlgorithm
+DiffEqBase.AbstractSecondOrderODEIntegrator
+```
+
+### Split ODEs
+
+```@docs
+SplitFunction
+DiffEqBase.AbstractSplitODEProblem
+SplitODEProblem
+```
+
+### Steady state problems
+
+```@docs
+DiffEqBase.AbstractSteadyStateProblem
+SteadyStateProblem
+DiffEqBase.AbstractSteadyStateSolution
+DiffEqBase.SteadyStateSolution
+DiffEqBase.AbstractSteadyStateAlgorithm
+DiffEqBase.AbstractSteadyStateIntegrator
+```
+
+### Boundary value problems
+
+```@docs
+DiffEqBase.TwoPointBVPFunction
+DiffEqBase.AbstractBVProblem
+DiffEqBase.StandardBVProblem
+BVProblem
+TwoPointBVProblem
+```
+
+### Analytical problems
+
+```@docs
+AbstractAnalyticalProblem
+AnalyticalProblem
+DiffEqBase.AbstractAnalyticalSolution
+```
+
+
+## SDE
+
+SDE problems are subtypes of RODE problems.
+
+```@docs
+DiffEqBase.AbstractSDEFunction
+SDEFunction
+DiffEqBase.AbstractSDEProblem
+DiffEqBase.StandardSDEProblem
+SDEProblem
+DiffEqBase.AbstractSDEAlgorithm
+DiffEqBase.AbstractSDEIntegrator
+```
+
+### Split SDEs
+
+```@docs
+SplitSDEFunction
+DiffEqBase.AbstractSplitSDEProblem
+SplitSDEProblem
+```
+
+
+## RODE
+
+```@docs
+DiffEqBase.AbstractRODEFunction
+RODEFunction
+DiffEqBase.AbstractRODEProblem
+RODEProblem
+DiffEqBase.AbstractRODESolution
+DiffEqBase.RODESolution
+DiffEqBase.AbstractRODEAlgorithm
+DiffEqBase.AbstractRODEIntegrator
+```
+
+
+## DDE
+
+```@docs
+DiffEqBase.AbstractDDEFunction
+DDEFunction
+DiffEqBase.AbstractDDEProblem
+DDEProblem
+DiffEqBase.AbstractConstantLagDDEProblem
+DiffEqBase.AbstractDDESolution
+DiffEqBase.AbstractDDEAlgorithm
+DiffEqBase.AbstractDDEIntegrator
+DiffEqBase.AbstractHistoryFunction
+```
+
+
+## SDDE
+
+```@docs
+DiffEqBase.AbstractSDDEFunction
+SDDEFunction
+DiffEqBase.AbstractSDDEProblem
+SDDEProblem
+DiffEqBase.AbstractConstantLagSDDEProblem
+DiffEqBase.AbstractSDDEAlgorithm
+DiffEqBase.AbstractSDDEIntegrator
+```
+
+
+## DAE
+
+```@docs
+DiffEqBase.AbstractDAEFunction
+DAEFunction
+DiffEqBase.AbstractDAEProblem
+DAEProblem
+DiffEqBase.AbstractDAESolution
+DiffEqBase.DAESolution
+DiffEqBase.AbstractDAEAlgorithm
+DiffEqBase.AbstractDAEIntegrator
+```
+
+
+### PDE
+
+```@docs
+DiffEqBase.AbstractPDEProblem
+PDEProblem
+```
+
+
+## Jump problems
+
+```@docs
+DiffEqBase.AbstractJumpProblem
+```
+
+
+## Noise problems
+
+```@docs
+DiffEqBase.AbstractNoiseProblem
+NoiseProblem
+```
+
+
+## Basic problems (for testing?)
+
+### Linear
+
+```@docs
+DiffEqBase.AbstractLinearProblem
+DiffEqBase.LinearProblem
+DiffEqBase.AbstractLinearSolution
+DiffEqBase.LinearSolution
+DiffEqBase.AbstractLinearAlgorithm
+```
+
+### Nonlinear
+
+```@docs
+DiffEqBase.AbstractNonlinearProblem
+DiffEqBase.NonlinearProblem
+DiffEqBase.AbstractNonlinearSolution
+DiffEqBase.AbstractNonlinearAlgorithm
+```
+
+### Quadrature
+
+```@docs
+DiffEqBase.AbstractQuadratureProblem
+DiffEqBase.QuadratureProblem
+DiffEqBase.AbstractQuadratureSolution
+DiffEqBase.AbstractQuadratureAlgorithm
+```
+
+
+## Sensitivity problems
+```@docs
+DiffEqBase.DESensitivity
+DiffEqBase.AbstractSensitivitySolution
+```

--- a/docs/src/apis/diffeqbase/ensembles.md
+++ b/docs/src/apis/diffeqbase/ensembles.md
@@ -1,0 +1,86 @@
+# Ensembles
+
+
+## Types
+
+```@docs
+DiffEqBase.AbstractEnsembleProblem
+EnsembleProblem
+DiffEqBase.AbstractEnsembleSolution
+EnsembleSolution
+EnsembleTestSolution
+EnsembleSummary
+DiffEqBase.EnsembleAlgorithm
+DiffEqBase.BasicEnsembleAlgorithm
+DiffEqBase.AbstractEnsembleEstimator
+EnsembleSerial
+EnsembleDistributed
+EnsembleThreads
+EnsembleSplitThreads
+```
+
+
+## Functions
+
+```@docs
+DiffEqBase.calculate_ensemble_errors
+DiffEqBase.batch_func
+DiffEqBase.solve_batch
+DiffEqBase.thread_monte
+DiffEqBase.vector_batch_data_to_arr
+```
+
+### Analysis
+
+```@docs
+EnsembleAnalysis.get_timestep
+EnsembleAnalysis.get_timepoint
+EnsembleAnalysis.timestep_mean
+EnsembleAnalysis.timestep_median
+EnsembleAnalysis.timestep_meancor
+EnsembleAnalysis.timestep_meancov
+EnsembleAnalysis.timestep_meanvar
+EnsembleAnalysis.timestep_quantile
+EnsembleAnalysis.timestep_weighted_meancov
+EnsembleAnalysis.timepoint_mean
+EnsembleAnalysis.timepoint_median
+EnsembleAnalysis.timepoint_meancor
+EnsembleAnalysis.timepoint_meancov
+EnsembleAnalysis.timepoint_meanvar
+EnsembleAnalysis.timepoint_quantile
+EnsembleAnalysis.timepoint_weighted_meancov
+EnsembleAnalysis.timeseries_steps_mean
+EnsembleAnalysis.timeseries_steps_median
+EnsembleAnalysis.timeseries_steps_meancor
+EnsembleAnalysis.timeseries_steps_meancov
+EnsembleAnalysis.timeseries_steps_meanvar
+EnsembleAnalysis.timeseries_steps_quantile
+EnsembleAnalysis.timeseries_steps_weighted_meancov
+EnsembleAnalysis.timeseries_point_mean
+EnsembleAnalysis.timeseries_point_median
+EnsembleAnalysis.timeseries_point_meancor
+EnsembleAnalysis.timeseries_point_meancov
+EnsembleAnalysis.timeseries_point_meanvar
+EnsembleAnalysis.timeseries_point_quantile
+EnsembleAnalysis.timeseries_point_weighted_meancov
+EnsembleAnalysis.componentwise_mean
+EnsembleAnalysis.componentwise_meancor
+EnsembleAnalysis.componentwise_meancov
+EnsembleAnalysis.componentwise_meanvar
+EnsembleAnalysis.componentwise_vectors_timestep
+EnsembleAnalysis.componentwise_weighted_meancov
+EnsembleAnalysis.componentwise_vectors_timepoint
+```
+
+
+## Deprecated "Monte Carlo" aliases
+
+The following are deprecated and are just aliases to the `Ensemble` equivalents:
+
+* `AbstractMonteCarloProblem`: [`AbstractEnsembleProblem`](@ref DiffEqBase.AbstractEnsembleProblem)
+* `MonteCarloProblem`: [`EnsembleProblem`](@ref)
+* `MonteCarloAlgorithm`: [`EnsembleAlgorithm`](@ref DiffEqBase.EnsembleAlgorithm)
+* `AbstractMonteCarloSolution`: [`AbstractEnsembleSolution`](@ref DiffEqBase.AbstractEnsembleSolution)
+* `MonteCarloSolution`: [`EnsembleSolution`](@ref)
+* `MonteCarloSummary`: [`EnsembleSummary`](@ref)
+* `calculate_monte_errors`: [`calculate_ensemble_errors`](@ref DiffEqBase.calculate_ensemble_errors)

--- a/docs/src/apis/diffeqbase/functions.md
+++ b/docs/src/apis/diffeqbase/functions.md
@@ -1,0 +1,23 @@
+# DE functions
+
+
+## Base Types
+
+```@docs
+DiffEqBase.AbstractDiffEqFunction
+```
+
+
+## Type traits
+
+```@docs
+isinplace
+DiffEqBase.is_diagonal_noise
+DiffEqBase.has_analytic
+DiffEqBase.has_jac
+DiffEqBase.has_tgrad
+DiffEqBase.has_Wfact
+DiffEqBase.has_Wfact_t
+DiffEqBase.has_paramjac
+DiffEqBase.has_syms
+```

--- a/docs/src/apis/diffeqbase/integrators.md
+++ b/docs/src/apis/diffeqbase/integrators.md
@@ -1,0 +1,61 @@
+# Integrators
+
+
+## Types
+
+```@docs
+DiffEqBase.DEIntegrator
+DiffEqBase.IntegratorIntervals
+DiffEqBase.IntegratorTuples
+```
+
+
+## Interface
+
+```@docs
+DiffEqBase.initialize!(u, t, integrator::DiffEqBase.DEIntegrator, any_modified, c)
+DiffEqBase.step!
+DiffEqBase.addat!
+DiffEqBase.get_tmp_cache
+DiffEqBase.user_cache
+DiffEqBase.u_cache
+DiffEqBase.du_cache
+DiffEqBase.ratenoise_cache
+DiffEqBase.rand_cache
+DiffEqBase.full_cache
+DiffEqBase.resize_non_user_cache!
+DiffEqBase.deleteat_non_user_cache!
+DiffEqBase.addat_non_user_cache!
+DiffEqBase.terminate!
+DiffEqBase.get_du
+DiffEqBase.get_du!
+DiffEqBase.get_dt
+DiffEqBase.get_proposed_dt
+DiffEqBase.u_modified!
+DiffEqBase.savevalues!
+DiffEqBase.add_tstop!
+DiffEqBase.add_saveat!
+DiffEqBase.set_abstol!
+DiffEqBase.set_reltol!
+DiffEqBase.reinit!
+DiffEqBase.auto_dt_reset!
+DiffEqBase.change_t_via_interpolation!
+DiffEqBase.addsteps!
+DiffEqBase.reeval_internals_due_to_modification!
+DiffEqBase.set_t!
+DiffEqBase.set_u!
+DiffEqBase.set_ut!
+DiffEqBase.addat!
+DiffEqBase.last_step_failed
+DiffEqBase.check_error
+DiffEqBase.check_error!
+DiffEqBase.intervals
+```
+
+
+## Traits
+
+
+```@docs
+DiffEqBase.has_reinit
+```

--- a/docs/src/apis/diffeqbase/interpolation.md
+++ b/docs/src/apis/diffeqbase/interpolation.md
@@ -1,0 +1,20 @@
+# Interpolation
+
+
+## Types
+
+```@docs
+DiffEqBase.AbstractDiffEqInterpolation
+DiffEqBase.ConstantInterpolation
+DiffEqBase.LinearInterpolation
+DiffEqBase.HermiteInterpolation
+```
+
+
+## Functions
+
+```@docs
+DiffEqBase.interpolation
+DiffEqBase.interpolation!
+DiffEqBase.interpolant
+```

--- a/docs/src/apis/diffeqbase/noise.md
+++ b/docs/src/apis/diffeqbase/noise.md
@@ -1,0 +1,6 @@
+# Noise processes
+
+
+```@docs
+DiffEqBase.AbstractNoiseProcess
+```

--- a/docs/src/apis/diffeqbase/operators.md
+++ b/docs/src/apis/diffeqbase/operators.md
@@ -1,0 +1,28 @@
+# Operators
+
+
+## Types
+
+```@docs
+DiffEqBase.AbstractDiffEqOperator
+DiffEqBase.AbstractDiffEqLinearOperator
+DiffEqBase.FactorizedDiffEqArrayOperator
+DiffEqArrayOperator
+DiffEqBase.AffineDiffEqOperator
+DiffEqScalar
+DiffEqIdentity
+```
+
+
+## Functions
+
+```@docs
+update_coefficients!
+DiffEqBase.setval!
+isconstant
+DiffEqBase.islinear
+DiffEqBase.has_expmv
+DiffEqBase.has_exp
+DiffEqBase.has_mul
+DiffEqBase.has_ldiv
+```

--- a/docs/src/apis/diffeqbase/other.md
+++ b/docs/src/apis/diffeqbase/other.md
@@ -1,0 +1,4 @@
+
+```@docs
+DiffEqBase.DEElement
+```

--- a/docs/src/apis/diffeqbase/overview.md
+++ b/docs/src/apis/diffeqbase/overview.md
@@ -1,0 +1,43 @@
+# DiffEqBase API Overview
+
+
+## DE types
+
+`DiffEqBase.jl` defines specialized types and functions for several categories
+of differential equation problems (ODEs, SDEs, etc.). Most categories have
+definitions for the following:
+
+* Function types
+  (`<: `[`AbstractDiffEqFunction`](@ref DiffEqBase.AbstractDiffEqFunction)),
+  which wrap a Julia function along with additional data such as a mass matrix
+  or additional functions for calculating Jacobians.
+* Problem types (`<:`[`DEProblem`](@ref DiffEqBase.DEProblem)), which represent
+  a problem to be solved. They include a function of the corresponding type
+  along with information such as initial conditions, parameter values, and the
+  time span to solve.
+* Algorithm types (`<: `[`DEAlgorithm`](@ref DiffEqBase.DEAlgorithm)), which solve
+  `DEProblem`s.
+* Solution types (`<: `[`DESolution`](@ref DiffEqBase.DESolution)), which are
+  the result of an algorithm solving a `DEProblem`.
+
+See [DE Types](@ref de_types) for documentation of specialized code for each problem type.
+
+
+## Type parameters
+
+The following are common type parameters that appear throughout the package:
+
+* `uType` - Element type of the state vector of a DE function or problem.
+  Typically a subtype of `Real`.
+* `tType` - Type of time variable used in a DE function or problem. Typically a
+  subtype of `Real`.
+* `isinplace` - Boolean value which indicates whether a DE function operates
+  in-place (sets values of an array passed as its first argument rather than
+  returning a new array). Also appears as `iip`.
+* `ND`
+
+
+## Index
+
+```@index
+```

--- a/docs/src/apis/diffeqbase/problems.md
+++ b/docs/src/apis/diffeqbase/problems.md
@@ -1,0 +1,27 @@
+# Problems
+
+
+## Base types
+
+```@docs
+DiffEqBase.DEProblem
+```
+
+
+## Interface
+
+```@docs
+remake
+```
+
+## Other functions
+
+```@docs
+DiffEqBase.get_concrete_problem
+DiffEqBase.get_concrete_u0
+DiffEqBase.get_concrete_tspan
+DiffEqBase.promote_tspan
+DiffEqBase.eval_u0
+DiffEqBase.adaptive_warn
+DiffEqBase.adaptive_integer_warn
+```

--- a/docs/src/apis/diffeqbase/solutions.md
+++ b/docs/src/apis/diffeqbase/solutions.md
@@ -1,0 +1,20 @@
+# Solutions
+
+
+## Base types
+
+The type alias `DESolution` is a union of the base problem types
+[`DiffEqBase.AbstractTimeseriesSolution`](@ref),
+[`DiffEqBase.AbstractNoTimeSolution`](@ref),
+[`DiffEqBase.AbstractEnsembleSolution`](@ref), and
+[`DiffEqBase.AbstractNoiseProcess`](@ref).
+
+```@docs
+DESolution
+DiffEqBase.AbstractNoTimeSolution
+DiffEqBase.AbstractTimeseriesSolution
+```
+
+## Interface
+
+TODO

--- a/docs/src/apis/diffeqbase/solvers.md
+++ b/docs/src/apis/diffeqbase/solvers.md
@@ -1,0 +1,36 @@
+# Solvers
+
+
+## Types
+
+```@docs
+DiffEqBase.DEAlgorithm
+```
+
+### Type traits
+
+```@docs
+DiffEqBase.isautodifferentiable
+DiffEqBase.isadaptive
+DiffEqBase.isdiscrete
+```
+
+
+## Interface
+
+```@docs
+DiffEqBase.init_call
+DiffEqBase.init
+DiffEqBase.solve_call
+DiffEqBase.solve
+```
+
+
+## Tableaus
+
+```@docs
+DiffEqBase.Tableau
+DiffEqBase.ODERKTableau
+DiffEqBase.ImplicitRKTableau
+DiffEqBase.ExplicitRKTableau
+```

--- a/docs/src/apis/diffeqbase/utility.md
+++ b/docs/src/apis/diffeqbase/utility.md
@@ -1,0 +1,15 @@
+# Utility
+
+
+## Functions
+
+```@docs
+DiffEqBase.num_types_in_tuple
+DiffEqBase.numargs
+DiffEqBase.copy_fields
+DiffEqBase.undefined_exports
+DiffEqBase.warn_compat
+DiffEqBase.@def
+DiffEqBase.@add_kwonly
+DiffEqBase.@CSI_str
+```


### PR DESCRIPTION
Created a skeleton for the `DiffEqBase` API documentation. I haven't actually written much content, but there are docstrings added for nearly all types and most functions categorized into different pages and subheadings. I'm hoping having this framework in place will make it easy for people who know the codebase better than I to start filling in the rest.

I created a PR to `DiffEqBase` that added docstring stubs for many types and functions that were lacking them, so until that's accepted you'll get a lot of "no docs found for ..." warnings.