### PR TITLE
The Wiener process is not white noise

### DIFF
--- a/docs/src/features/noise_process.md
+++ b/docs/src/features/noise_process.md
@@ -121,11 +121,11 @@ This section describes the available `NoiseProcess` types. Note that all
 keyword arguments are splatted into the `NoiseProcess` constructor, and thus
 options like `reset` are available on the pre-built processes.
 
-### Wiener Process (Red Noise)
+### Wiener Process
 
-The `WienerProcess`, also known as red noise, Brownian motion, or
-the noise in the Langevin equation, is the stationary process with distribution
-`N(0,t)`. The constructor is:
+The `WienerProcess`, also known as Brownian motion, or
+the noise in the Langevin equation, is the stationary process with 
+white noise increments and a distribution `N(0,t)`. The constructor is:
 
 ```julia
 WienerProcess(t0,W0,Z0=nothing;kwargs...)

--- a/docs/src/features/noise_process.md
+++ b/docs/src/features/noise_process.md
@@ -121,9 +121,9 @@ This section describes the available `NoiseProcess` types. Note that all
 keyword arguments are splatted into the `NoiseProcess` constructor, and thus
 options like `reset` are available on the pre-built processes.
 
-### Wiener Process (White Noise)
+### Wiener Process (Red Noise)
 
-The `WienerProcess`, also known as Gaussian white noise, Brownian motion, or
+The `WienerProcess`, also known as red noise, Brownian motion, or
 the noise in the Langevin equation, is the stationary process with distribution
 `N(0,t)`. The constructor is:
 


### PR DESCRIPTION
I believe there is a mistake here, the Wiener process is not white noise, but rather Brownian (or red) noise. The increments are white Gaussian noise, but the process is not. See [the Wikipedia article](https://en.wikipedia.org/wiki/Wiener_process).