### PR TITLE
extract_local_sensitivities(sol,i::Integer) broken

### DIFF
--- a/docs/src/analysis/sensitivity.md
+++ b/docs/src/analysis/sensitivity.md
@@ -301,14 +301,13 @@ We can use the following helper functions to extract the sensitivity information
 
 ```julia
 x,dp = extract_local_sensitivities(sol)
-x,dp = extract_local_sensitivities(sol,i)
 x,dp = extract_local_sensitivities(sol,t)
 ```
 
 In each case, `x` is the ODE values and `dp` is the matrix of sensitivities
 where `dp[i]` is the gradient of component `i` by the parameters. The first gives
-the full timeseries of values. The second returns the `i`th values, while the third
-interpolates to calculate the sensitivities at time `t`. For example, if we do:
+the full timeseries of values. The second interpolates to calculate the sensitivities at time `t`.
+For example, if we do:
 
 ```julia
 x,dp = extract_local_sensitivities(sol)


### PR DESCRIPTION
extract_local_sensitivities(sol,i::Integer) doesn't work the way it is described,  looking at the source it can be seen that i is not the component but the discrete time ith step -- which is not what a user is interested in (since the time points are chosen by the adaptive time stepping)

The correct implementation of  extract_local_sensitivities(sol,i::Integer) would have
sol[i, :] somewhere.

I think, it is enough to provide `extract_local_sensitivities(sol)` and ` extract_local_sensitivities(sol,t::T) where T <: AbstractFloat` and delete `extract_local_sensitivities(sol, i)` from documentation and code basis.